### PR TITLE
Update to pass baseSha to upload endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the API key to your secrets in your repository. **Do not leave this key in p
 ### Incorporate in your workflow
 
 Build your artifact in a step before the Emerge upload action. Pass the generated artifact's path as the `artifact_path`
-argument, and your Emerge API key secret as the `emerge_api_key` argument 
+argument, and your Emerge API key secret as the `emerge_api_key` argument:
 
 ```yaml
 name: Your workflow
@@ -45,7 +45,7 @@ jobs:
       - name: Generate Android release bundle
         run: ./gradlew bundleRelease
       - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@v1.0.0
+        uses: EmergeTools/emerge-upload-action@v1.0.1
         with:
           artifact_path: ./app/build/outputs/bundle/release/app-release.aab
           emerge_api_key: ${{ secrets.EMERGE_API_KEY }}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type UploadInputs = {
   filename: string
   emergeApiKey: string
   sha: string
+  baseSha: string
   repoName: string
 
   // Required for PRs

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -12,6 +12,7 @@ async function run(): Promise<void> {
     prNumber: inputs.prNumber,
     branch: inputs.branchName,
     sha: inputs.sha,
+    baseSha: inputs.baseSha,
     repoName: inputs.repoName,
     buildType: inputs.buildType,
   };


### PR DESCRIPTION
- Updates the Github action to pass the `baseSha` parameter to the `/upload` enpoint in Emerge. This fixes a bug in which the `baseSha` could be outdated and therefore incorrect from a PR if not updated on each push or commit to a PR. This explicitly pulls the sha from the GH action event data and passes it to our `/upload` API, which should provide the most up-to-date and correct baseSha for a given commit.
- Updates the action in a push event to also pass the `before` sha of the previous commit. This sha could be all `0000....`, but that is an extremely rare case in which it's the initial commit to a branch. Given we encourage Emerge running on main/other primary branches, this will likely never be hit.
- Updates version in readme to 1.0.1, which will be the upcoming release of this fix.