### PR TITLE
feat: support 'pull_request_target' trigger

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6228,7 +6228,7 @@ function getInputs() {
         encoding: 'utf8',
     });
     const eventFileJson = JSON.parse(eventFile);
-    if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
+    if (process.env.GITHUB_EVENT_NAME === 'pull_request' || process.env.GITHUB_EVENT_NAME === 'pull_request_target') {
         sha = (_e = (_d = (_c = (_b = eventFileJson === null || eventFileJson === void 0 ? void 0 : eventFileJson.pull_request) === null || _b === void 0 ? void 0 : _b.head) === null || _c === void 0 ? void 0 : _c.sha) !== null && _d !== void 0 ? _d : process.env.GITHUB_SHA) !== null && _e !== void 0 ? _e : '';
         baseSha = (_h = (_g = (_f = eventFileJson === null || eventFileJson === void 0 ? void 0 : eventFileJson.pull_request) === null || _f === void 0 ? void 0 : _f.base) === null || _g === void 0 ? void 0 : _g.sha) !== null && _h !== void 0 ? _h : '';
         branchName = (_j = process.env.GITHUB_HEAD_REF) !== null && _j !== void 0 ? _j : '';
@@ -6263,9 +6263,12 @@ function getInputs() {
     }
     // Required for PRs
     const refName = (_o = process.env.GITHUB_REF) !== null && _o !== void 0 ? _o : '';
-    const prNumber = (0, utils_1.getPRNumber)(refName);
+    var prNumber = (0, utils_1.getPRNumber)(refName);
     if (refName.includes('pull') && !prNumber) {
         core.setFailed('Could not get prNumber for a PR triggered build.');
+    }
+    if (!prNumber) {
+        prNumber = eventFileJson === null || eventFileJson === void 0 ? void 0 : eventFileJson.number;
     }
     // Optional args
     let buildType = core.getInput('build_type');

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -29,7 +29,7 @@ function getInputs(): UploadInputs {
     encoding: 'utf8',
   });
   const eventFileJson = JSON.parse(eventFile);
-  if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
+  if (process.env.GITHUB_EVENT_NAME === 'pull_request' || process.env.GITHUB_EVENT_NAME === 'pull_request_target') {
     sha = eventFileJson?.pull_request?.head?.sha ?? process.env.GITHUB_SHA ?? '';
     baseSha = eventFileJson?.pull_request?.base?.sha ?? '';
     branchName = process.env.GITHUB_HEAD_REF ?? '';
@@ -66,11 +66,13 @@ function getInputs(): UploadInputs {
 
   // Required for PRs
   const refName = process.env.GITHUB_REF ?? '';
-  const prNumber = getPRNumber(refName);
+  var prNumber = getPRNumber(refName);
   if (refName.includes('pull') && !prNumber) {
     core.setFailed('Could not get prNumber for a PR triggered build.');
   }
-
+  if (!prNumber) {
+    prNumber = eventFileJson?.number
+  }
   // Optional args
   let buildType = core.getInput('build_type');
   if (buildType === '') {


### PR DESCRIPTION
`pull_request_target` trigger is needed to use emerge-upload-action in PRs from forked repositories.
Standard `pull_request` trigger does not allow access to secrets (EMERGE_API_TOKEN) when PR's head points to forked repo.
I tested this improvement on my repositories and got this output:
```
##[debug]requestBody: {"filename":"artifact.zip","prNumber":184,"branch":"test-gh-action","sha":"478e84922bf5f03047323d853ba006c13a39d5ea","baseSha":"2b993f7ec6e88206c682a4040fde6cecb684f64d","repoName":"rakutentech/ios-inappmessaging"}
```

Docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target